### PR TITLE
Do not use second parameter for getTemplateGroup

### DIFF
--- a/dca/tl_module.php
+++ b/dca/tl_module.php
@@ -280,7 +280,7 @@ class tl_module_news4ward extends Backend
 			$intPid = Input::get('id');
 		}
 
-		return $this->getTemplateGroup('news4ward_', $intPid);
+		return $this->getTemplateGroup('news4ward_');
 	}
 
 
@@ -298,7 +298,7 @@ class tl_module_news4ward extends Backend
 			$intPid = Input::get('id');
 		}
 
-		return $this->getTemplateGroup('mod_news4ward_reader', $intPid);
+		return $this->getTemplateGroup('mod_news4ward_reader');
 	}
 }
 


### PR DESCRIPTION
Not sure if anyone still maintains this, but on the off chance someone can merge and tag this … ;)

https://community.contao.org/de/showthread.php?79287-Probleme-mit-news4ward